### PR TITLE
to add filename into the featuredict

### DIFF
--- a/tensorflow_datasets/image_classification/places365_small.py
+++ b/tensorflow_datasets/image_classification/places365_small.py
@@ -62,8 +62,9 @@ class Places365Small(tfds.core.GeneratorBasedBuilder):
         features=tfds.features.FeaturesDict({
             "image": tfds.features.Image(shape=_IMAGE_SHAPE),
             "label": tfds.features.ClassLabel(names_file=names_file),
+            "filename": tfds.features.Text(),
         }),
-        supervised_keys=("image", "label"),
+        supervised_keys=("image", "label", "filename"),
         homepage="http://places2.csail.mit.edu/",
         citation=_CITATION)
 
@@ -137,4 +138,4 @@ class Places365Small(tfds.core.GeneratorBasedBuilder):
       chop = len(path_prefix) if split_name == "train" else len(path_prefix) + 1
       key = fname[chop:]
       class_id = file_to_class[key]
-      yield fname, {"image": fobj, "label": class_id}
+      yield fname, {"image": fobj, "label": class_id, "filename": fname}


### PR DESCRIPTION
I am the author of the Places365. To make the KYD discover the real filename rather than the key, I modified the file to include filename, suggested by Daniel Smilkov (smilkov@google.com). We hope to fix the issues identified in the knowyourdata for our Places database.

Thank you for your contribution!

Please read https://www.tensorflow.org/datasets/contribute#pr_checklist to make sure your PR follows the guidelines.

# Add Dataset

* Dataset Name: <name>
* Issue Reference: <link>
* `dataset_info.json` Gist: <link>

## Description

<description>

## Checklist

* [ ] Address all TODO's
* [ ] Add alphabetized import to subdirectory's `__init__.py`
* [ ] Run `download_and_prepare` successfully
* [ ] Add [checksums file](https://www.tensorflow.org/datasets/add_dataset#2_run_download_and_prepare_locally)
* [ ] Properly cite in `BibTeX` format
* [ ] Add passing test(s)
* [ ] Add test data
* [ ] If using additional dependencies (e.g. `scipy`), use [lazy_imports](https://www.tensorflow.org/datasets/add_dataset#extra_dependencies) (if applicable)
* [ ] Add data generation script (if applicable)
* [ ] [Lint](https://www.tensorflow.org/datasets/add_dataset#5_check_your_code_style) code
